### PR TITLE
Communication errors with Azure Event Hub is ignored., #2

### DIFF
--- a/src/NLog.Targets.AzureEventHub/AzureEventHubTarget.cs
+++ b/src/NLog.Targets.AzureEventHub/AzureEventHubTarget.cs
@@ -34,7 +34,16 @@ namespace NLog.Targets
         /// <param name="logEvent"></param>
         protected override void Write(LogEventInfo logEvent)
         {
-            SendAsync(PartitionKey, logEvent);
+            var sendTask = SendAsync(PartitionKey, logEvent);
+
+            try
+            {
+                sendTask.Wait();
+            }
+            catch (AggregateException ae)
+            {
+                throw ae.InnerException;
+            }
         }
 
         private async Task<bool> SendAsync(string partitionKey, LogEventInfo logEvent)

--- a/src/NLog.Targets.AzureEventHub/AzureEventHubTarget.cs
+++ b/src/NLog.Targets.AzureEventHub/AzureEventHubTarget.cs
@@ -28,6 +28,15 @@ namespace NLog.Targets
         /// </summary>
         public string PartitionKey { get; set; }
 
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _eventHubClient.Close();
+                _messsagingFactory.Close();
+            }
+        }
+
         /// <summary>
         /// Takes the contents of the LogEvent and sends the message to EventHub
         /// </summary>


### PR DESCRIPTION
Fixed issue #2.

This change makes Write behave synchronously. This is the expected behavior with NLog.

If you want asynchronous behavior, the target should be wrapped with BufferingWrapper:
https://github.com/nlog/NLog/wiki/BufferingWrapper-target
